### PR TITLE
add dmac_signed

### DIFF
--- a/R/MeasEquiv_EffectSize_Base.R
+++ b/R/MeasEquiv_EffectSize_Base.R
@@ -124,6 +124,117 @@ item_dmacs <- function (LambdaR, LambdaF,
 
 
 
+#' dmacs measurement nonequivalence effect size (signed)
+#'
+#' \code{item_dmacs_signed} computes the dmacs signed effect size for a single
+#' indicator relative to a single factor in a single focal group
+#'
+#' \code{item_dmacs_signed} is called by \code{dmacs_summary_single}, which in
+#' turn is called by \code{\link{lavaan_dmacs}} and \code{\link{mplus_dmacs}},
+#' which are the only functions in this package intended for casual users
+#'
+#' @param LambdaR is the factor loading of the indicator onto the factor of
+#' interest for the reference group.
+#' @param LambdaF is the factor loading of the indicator onto the factor of
+#' interest for the focal group.
+#' @param NuR is the indicator intercept for the reference group.
+#' @param NuF is the indicator intercept for the focal group.
+#' @param MeanF is the factor mean in the focal group
+#' @param VarF is the factor variances in the focal group.
+#' @param SD is the indicator standard deviations to be used as
+#' the denominator of the dmacs effect size. This will usually either be
+#' pooled standard deviation for the indicator or the standard deviation
+#' for the indicator in the reference group.
+#' @param ThreshR is a vector of thresholds (for categorical indicators)
+#' for the reference group. Defaults to \code{NULL} for continuous
+#' indicators.
+#' @param ThreshF is a vector of thresholds (for categorical indicators)
+#' for the focal group. Defaults to \code{NULL} for continuous
+#' indicators.
+#' @param ThetaR is the indicator residual variance in the
+#' reference group. Defaults to \code{NULL} for continuous
+#' indicators.
+#' @param ThetaF is the indicator residual variance in the
+#' focal group. Defaults to \code{NULL} for continuous
+#' indicators.
+#' @param categorical is a Boolean variable declaring whether the variables
+#' in the model are ordered categorical. Models in which some variables are
+#' categorical and others are continuous are not supported. If no value is
+#' provided, categorical defaults to \code{FALSE}, although if a vector of
+#' thresholds are provided, categorical will be forced to
+#' \code{TRUE}. A graded response model with probit link (e.g., DWLS in
+#' lavaan or WLSMV in Mplus) is used for categorical variables. If you desire
+#' for other categorical models (e.g., IRT parameterization) to be supported,
+#' e-mail the maintainer.
+#'
+#' @return The dmacs signed effect size of equation 3 of Nye, Bradburn,
+#' Olenick, Bialko, & Drasgow, F. (2019).
+#'
+#' @examples
+#' LambdaF <- 0.74
+#' LambdaR <- 0.76
+#' NuF     <- 1.28
+#' NuR     <- 0.65
+#' MeanF   <- 0.21
+#' VarF    <- 1.76
+#' SD      <- 1.85
+#' item_dmacs_signed(LambdaR, LambdaF, NuR, NuF, MeanF, VarF, SD)
+#'
+#' @section References:
+#' Nye, C. D., Bradburn, J., Olenick, J., Bialko, C., & Drasgow, F. (2019).
+#' How Big Are My Effects? Examining the Magnitude of Effect Sizes in Studies
+#' of Measurement Equivalence. Organizational Research Methods, 22(3),
+#' 678–709. https://doi.org/10.1177/1094428118761122
+#'
+#' @export
+#' @importFrom stats dnorm
+#' @importFrom stats integrate
+
+item_dmacs_signed <- function (LambdaR, LambdaF,
+                               NuR, NuF,
+                               MeanF, VarF, SD,
+                               ThreshR = NULL, ThreshF = NULL,
+                               ThetaR = NULL, ThetaF = NULL,
+                               categorical = FALSE) {
+
+  # Use Thresholds as a check for categorical-ness
+  if (!is.null(ThreshR)) {
+    categorical <- TRUE
+    ## If threshold vectors do not have the same length, throw an error
+    if (length(ThreshR) != length(ThreshF)) stop("Item must have same number of thresholds in both reference and focal group")
+
+  }
+
+  ## If item does not load on factor, return NA
+  if(LambdaR == 0) {return(NA)}
+
+  ## Create a function for the integrand using the expected value function expected_value
+  ## The sqrt(VarF) is there because we did a change of varianbles into the z metric
+
+  integrand <- function(z, LambdaR, LambdaF,
+                        NuR, NuF,
+                        ThreshR, ThreshF,
+                        ThetaR, ThetaF,
+                        MeanF, VarF, categorical) {
+
+    (expected_value(LambdaF, NuF, MeanF+z*sqrt(VarF), ThreshF, ThetaF, categorical) -
+       expected_value(LambdaR, NuR, MeanF+z*sqrt(VarF), ThreshR, ThetaR, categorical)) * dnorm(z) * sqrt(VarF)
+
+  }
+
+  ## Now, sum it to get the integral, and compute the effect size. Stepsize is in z units, not theta units!!
+  integrate(integrand, -Inf, Inf,
+            LambdaR, LambdaF,
+            NuR, NuF,
+            ThreshR, ThreshF,
+            ThetaR, ThetaF,
+            MeanF, VarF,
+            categorical = categorical)$value/SD
+
+}
+
+
+
 #' Expected bias to item mean
 #'
 #' \code{delta_mean_item} computes the expected bias in item mean due to

--- a/R/MeasEquiv_EffectSize_Wrappers.R
+++ b/R/MeasEquiv_EffectSize_Wrappers.R
@@ -256,6 +256,15 @@ dmacs_summary_single <- function (LambdaR, LambdaF,
                       categorical)
       names(DMACS) <- rownames(LambdaR)
 
+      DMACS_signed <- mapply(item_dmacs_signed,
+                             LambdaR, LambdaF,
+                             NuR, NuF,
+                             MeanF, VarF, SD,
+                             ThreshR, ThreshF,
+                             ThetaR, ThetaF,
+                             categorical)
+      names(DMACS_signed) <- rownames(LambdaR)
+
       ItemDeltaMean <- mapply(delta_mean_item,
                               LambdaR, LambdaF,
                               NuR, NuF,
@@ -268,7 +277,7 @@ dmacs_summary_single <- function (LambdaR, LambdaF,
       MeanDiff <- sum(ItemDeltaMean, na.rm = TRUE)
       names(MeanDiff) <- colnames(LambdaR)
 
-      list(DMACS = DMACS, ItemDeltaMean = ItemDeltaMean, MeanDiff = MeanDiff)
+      list(DMACS = DMACS, DMACS_signed = DMACS_signed, ItemDeltaMean = ItemDeltaMean, MeanDiff = MeanDiff)
 
     } else {
 
@@ -289,6 +298,17 @@ dmacs_summary_single <- function (LambdaR, LambdaF,
       colnames(DMACS) <- colnames(LambdaR)
       rownames(DMACS) <- rownames(LambdaR)
 
+      DMACS_signed <- as.data.frame(matrix(mapply(item_dmacs_signed,
+                                                  LambdaR, LambdaF,
+                                                  NuR, NuF,
+                                                  MeanF, VarF, SD,
+                                                  ThreshR, ThreshF,
+                                                  ThetaR, ThetaF,
+                                                  categorical),
+                                            nrow = nrow(LambdaR)))
+      colnames(DMACS_signed) <- colnames(LambdaR)
+      rownames(DMACS_signed) <- rownames(LambdaR)
+
 
       ## ItemDeltaMean has the same possible issues as DMACS
       ItemDeltaMean <- as.data.frame(matrix(mapply(delta_mean_item,
@@ -304,7 +324,7 @@ dmacs_summary_single <- function (LambdaR, LambdaF,
 
       MeanDiff <- colSums(ItemDeltaMean, na.rm = TRUE)
 
-      list(DMACS = DMACS, ItemDeltaMean = ItemDeltaMean, MeanDiff = MeanDiff)
+      list(DMACS = DMACS, DMACS_signed = DMACS_signed, ItemDeltaMean = ItemDeltaMean, MeanDiff = MeanDiff)
 
 
     }
@@ -316,6 +336,12 @@ dmacs_summary_single <- function (LambdaR, LambdaF,
                                   NuR, NuF,
                                   MeanF, VarF, SD, categorical = FALSE)
       names(DMACS) <- rownames(LambdaR)
+
+      DMACS_signed <- mapply(item_dmacs_signed, 
+                             LambdaR, LambdaF,
+                             NuR, NuF,
+                             MeanF, VarF, SD, categorical = FALSE)
+      names(DMACS_signed) <- rownames(LambdaR)
 
       ItemDeltaMean <- mapply(delta_mean_item, LambdaR, LambdaF,
                                                NuR, NuF,
@@ -346,6 +372,14 @@ dmacs_summary_single <- function (LambdaR, LambdaF,
       colnames(DMACS) <- colnames(LambdaR)
       rownames(DMACS) <- rownames(LambdaR)
 
+      DMACS_signed <- as.data.frame(matrix(mapply(item_dmacs_signed,
+                                           LambdaR, LambdaF,
+                                           NuR, NuF,
+                                           MeanF, VarF, SD, categorical = FALSE),
+                                    nrow = nrow(LambdaR)))
+      colnames(DMACS_signed) <- colnames(LambdaR)
+      rownames(DMACS_signed) <- rownames(LambdaR)
+
 
       ## ItemDeltaMean has the same possible issues as DMACS
       ItemDeltaMean <- as.data.frame(matrix(mapply(delta_mean_item,
@@ -362,7 +396,7 @@ dmacs_summary_single <- function (LambdaR, LambdaF,
       #VarDiff <- delta_var(LambdaR, LambdaF, VarF)
 
 
-      list(DMACS = DMACS, ItemDeltaMean = ItemDeltaMean, MeanDiff = MeanDiff)#, VarDiff = VarDiff)
+      list(DMACS = DMACS, DMACS_signed = DMACS_signed, ItemDeltaMean = ItemDeltaMean, MeanDiff = MeanDiff)#, VarDiff = VarDiff)
     }
 
   }


### PR DESCRIPTION
Dear @ddueber ,

Many thanks for your nice R package. I noticed that is missing the output of `dmacs_signed` by Nye, C. D., Bradburn, J., Olenick, J., Bialko, C., & Drasgow, F. (2019). This measure can be reported in addition to `dmacs` to get an impression of the direction of the effect.

The direction of the effect is already given by `item_delta_mean` in your package but `dmacs_signed` is recommended to report by Nye, et. al (2019).

Nye, C. D., Bradburn, J., Olenick, J., Bialko, C., & Drasgow, F. (2019). How Big Are My Effects? Examining the Magnitude of Effect Sizes in Studies of Measurement Equivalence. Organizational Research Methods, 22(3), 678–709. https://doi.org/10.1177/1094428118761122

I'm happy to improve this code if there are any suggestions from your side.

Best,
mutlusun